### PR TITLE
fix typo in `definition.validate`. `validate` could newer work with this bug.

### DIFF
--- a/datasift/Definition.cs
+++ b/datasift/Definition.cs
@@ -224,7 +224,7 @@ namespace datasift
                 {
                     throw new CompileFailedException("Validated successfully but no created_at in the response");
                 }
-                m_created_at = res.getDateTimeVal("hash", "yyyy-MM-dd HH:mm:ss");
+                m_created_at = res.getDateTimeVal("created_at", "yyyy-MM-dd HH:mm:ss");
 
                 if (!res.has("dpu"))
                 {


### PR DESCRIPTION
It is a bug fix.
