### PR TITLE
Definition.getDpuBreakdown needed csdl, it would not work with a hash.

### DIFF
--- a/datasift/Definition.cs
+++ b/datasift/Definition.cs
@@ -249,7 +249,7 @@ namespace datasift
         /// <returns>A Dpu object.</returns>
         public Dpu getDpuBreakdown()
         {
-            if (m_csdl.Length == 0)
+            if (m_csdl.Length == 0 && m_hash.Length == 0)
             {
                 throw new InvalidDataException("Cannot get the DPU breakdown for an empty definition");
             }


### PR DESCRIPTION
The Definition.getDpuBreakdown method, incorrectly, assumed that it needed the csdl, to get the dpu breakdown. It does not it needs the hash, or csdl (as it can convert csdl to a hash). Added fix to broaden pre-requisites, to allow hash or csdl (not just csdl).

see https://jiradatasift.atlassian.net/browse/ALT-30
