### PR TITLE
Get values for Reset time and TTL in api response

### DIFF
--- a/DataSift/APIHelpers.cs
+++ b/DataSift/APIHelpers.cs
@@ -94,6 +94,12 @@ namespace DataSift
                     case Constants.HEADER_RATELIMIT_COST:
                         result.Cost = int.Parse((string)header.Value);
                         break;
+                    case Constants.HEADER_RATELIMIT_RESET:
+                        result.Reset = long.Parse((string)header.Value);
+                        break;
+                    case Constants.HEADER_RATELIMIT_RESET_TTL:
+                        result.ResetTtl = int.Parse((string)header.Value);
+                        break;
                 }
             }
 

--- a/DataSift/Constants.cs
+++ b/DataSift/Constants.cs
@@ -28,6 +28,8 @@ namespace DataSift
         public const string HEADER_RATELIMIT_LIMIT = "x-ratelimit-limit";
         public const string HEADER_RATELIMIT_REMAINING = "x-ratelimit-remaining";
         public const string HEADER_RATELIMIT_COST = "x-ratelimit-cost";
+        public const string HEADER_RATELIMIT_RESET = "x-ratelimit-reset";
+        public const string HEADER_RATELIMIT_RESET_TTL = "x-ratelimit-reset-ttl";
         public const string HEADER_DATA_FORMAT = "x-datasift-format";
         public const string HEADER_CURSOR_CURRENT = "x-datasift-cursor-current";
         public const string HEADER_CURSOR_NEXT = "x-datasift-cursor-next";

--- a/DataSift/DataSift.csproj
+++ b/DataSift/DataSift.csproj
@@ -152,6 +152,7 @@
     <Compile Include="Enum\PushStatus.cs" />
     <Compile Include="Enum\Sample.cs" />
     <Compile Include="Enum\UsagePeriod.cs" />
+    <Compile Include="IDataSiftClient.cs" />
     <Compile Include="Messages.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rest\Account\Account.cs" />

--- a/DataSift/DataSift.nuspec
+++ b/DataSift/DataSift.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Datasift.net</id>
-        <version>1.6.0</version>
+        <version>1.6.1</version>
         <authors>Datasift</authors>
         <licenseUrl>https://github.com/datasift/datasift-dotnet/blob/master/LICENSE</licenseUrl>
         <projectUrl>https://github.com/datasift/datasift-dotnet/tree/master</projectUrl>

--- a/DataSift/DataSiftClient.cs
+++ b/DataSift/DataSiftClient.cs
@@ -16,7 +16,7 @@ using DataSift.Rest.Pylon;
 
 namespace DataSift
 {
-    public class DataSiftClient
+    public class DataSiftClient : IDataSiftClient
     {
         private string _username;
         private string _apikey;

--- a/DataSift/IDataSiftClient.cs
+++ b/DataSift/IDataSiftClient.cs
@@ -1,0 +1,29 @@
+﻿using DataSift.Enum;
+using DataSift.Rest;
+using DataSift.Rest.Account;
+using DataSift.Rest.Pylon;
+using DataSift.Streaming;
+
+namespace DataSift
+{
+    public interface IDataSiftClient
+    {
+        Account Account { get; }
+        Historics Historics { get; }
+        HistoricsPreview HistoricsPreview { get; }
+        ODP ODP { get; }
+        Push Push { get; }
+        Pylon Pylon { get; }
+        Source Source { get; }
+
+        RestAPIResponse Balance();
+        RestAPIResponse Compile(string csdl);
+        DataSiftStream Connect(bool secure = true, string domain = "stream.datasift.com", bool autoReconnect = true);
+        RestAPIResponse DPU(string hash = null, string historicsId = null);
+        IIngestAPIRequest GetIngestRequest();
+        IRestAPIRequest GetRequest();
+        PullAPIResponse Pull(string id, int? size = default(int?), string cursor = null);
+        RestAPIResponse Usage(UsagePeriod? period = default(UsagePeriod?));
+        RestAPIResponse Validate(string csdl);
+    }
+}

--- a/DataSift/Rest/RestAPIResponse.cs
+++ b/DataSift/Rest/RestAPIResponse.cs
@@ -28,5 +28,7 @@ namespace DataSift.Rest
         public int Limit { get; set; }
         public int Remaining { get; set; }
         public int Cost { get; set; }
+        public long Reset { get; set; }
+        public int ResetTtl { get; set; }
     }
 }


### PR DESCRIPTION
These values are useful and allow a client to stop trying the API when the ratelimit has been exceeded

I've also added a commit to create an interface IDataSiftClient which is useful for writing unit tests without needing to write a wrapper around DataSiftClient.